### PR TITLE
Rework Dockerfile for smaller and fewer layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM condaforge/linux-anvil
 
-# Install TeXLive, AMD APP SDK 3.0, and NVIDIA CUDA 9.0 for building OpenMM and Omnia projects
+# Install TeXLive, AMD APP SDK 3.0, and NVIDIA CUDA 9.1 for building OpenMM and Omnia projects
 
 #
 # Install EPEL and extra packages
@@ -11,21 +11,23 @@ FROM condaforge/linux-anvil
 # The other TeX packages installed with `tlmgr install` are required for OpenMM's sphinx docs
 # libXext libSM libXrender are required for matplotlib to work
 
-ADD http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm .
-RUN rpm -i --quiet epel-release-6-8.noarch.rpm && \
-    rm -rf epel-release-6-8.noarch.rpm
-
-RUN  yum install -y --quiet perl dkms libvdpau git wget libXext libSM libXrender groff
-
+# Download and install EPEL, install extra packages for TeX, AMD, and CUDA, cleanup yum
+RUN curl -L http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm --output epel-release-6-8.noarch.rpm && \
+    rpm -i --quiet epel-release-6-8.noarch.rpm && \
+    rm -rf epel-release-6-8.noarch.rpm && \
+    yum install -y --quiet perl dkms libvdpau git wget libXext libSM libXrender groff && \
+    yum clean -y --quiet expire-cache && \
+    yum clean -y --quiet all
 
 #
 # Install TeXLive
 #
 
-#ADD http://ctan.mackichan.com/systems/texlive/tlnet/install-tl-unx.tar.gz .
-ADD http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz .
+# Add config file from repo
 ADD texlive.profile .
-RUN tar -xzf install-tl-unx.tar.gz && \
+# Download, untar, install, remove install files, install additional packages
+RUN curl -L http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz --output install-tl-unx.tar.gz && \
+    tar -xzf install-tl-unx.tar.gz && \
     cd install-tl-* &&  ./install-tl -profile /texlive.profile && cd - && \
     rm -rf install-tl-unx.tar.gz install-tl-* texlive.profile && \
     /usr/local/texlive/2017/bin/x86_64-linux/tlmgr install \
@@ -40,11 +42,9 @@ ENV PATH=/usr/local/texlive/2017/bin/x86_64-linux:$PATH
 #
 
 
-# Install AMD APP SDK
-ADD http://s3.amazonaws.com/omnia-ci/AMD-APP-SDKInstaller-v3.0.130.135-GA-linux64.tar.bz2 .
-RUN pwd
-RUN ls -ltr
-RUN tar xjf AMD-APP-SDKInstaller-v3.0.130.135-GA-linux64.tar.bz2 && \
+# Download, untar, install AMD APP SDK, remove tarball, install script, and samples
+RUN curl -L http://s3.amazonaws.com/omnia-ci/AMD-APP-SDKInstaller-v3.0.130.135-GA-linux64.tar.bz2 > AMD-APP-SDKInstaller-v3.0.130.135-GA-linux64.tar.bz2 && \
+    tar xjf AMD-APP-SDKInstaller-v3.0.130.135-GA-linux64.tar.bz2 && \
     ./AMD-APP-SDK-v3.0.130.135-GA-linux64.sh -- -s -a yes && \
     rm -f AMD-APP-SDK-v3.0.130.135-GA-linux64.sh AMD-APP-SDKInstaller-v3.0.130.135-GA-linux64.tar.bz2 && \
     rm -rf /opt/AMDAPPSDK-3.0/samples/
@@ -54,13 +54,9 @@ ENV OPENCL_HOME=/opt/AMDAPPSDK-3.0 OPENCL_LIBPATH=/opt/AMDAPPSDK-3.0/lib/x86_64
 # Install CUDA 9.0
 #
 
-# CUDA requires dkms libvdpau
-RUN yum install -y --quiet dkms libvdpau
-
 # Install minimal CUDA components (this may be more than needed)
-ADD https://developer.nvidia.com/compute/cuda/9.1/Prod/local_installers/cuda-repo-rhel6-9-1-local-9.1.85-1.x86_64 .
-RUN mv cuda-repo-rhel6-9-1-local-9.1.85-1.x86_64 cuda-repo-rhel6-9-1-local-9.1.85-1.x86_64.rpm
-RUN rpm --quiet -i cuda-repo-rhel6-9-1-local-9.1.85-1.x86_64.rpm && \
+RUN curl -L https://developer.nvidia.com/compute/cuda/9.1/Prod/local_installers/cuda-repo-rhel6-9-1-local-9.1.85-1.x86_64 > cuda-repo-rhel6-9-1-local-9.1.85-1.x86_64.rpm && \
+    rpm --quiet -i cuda-repo-rhel6-9-1-local-9.1.85-1.x86_64.rpm && \
     yum --nogpgcheck localinstall -y --quiet /var/cuda-repo-9-1-local/cuda-minimal-build-9-1-9.1.85-1.x86_64.rpm && \
     yum --nogpgcheck localinstall -y --quiet /var/cuda-repo-9-1-local/cuda-cufft-dev-9-1-9.1.85-1.x86_64.rpm && \
     yum --nogpgcheck localinstall -y --quiet /var/cuda-repo-9-1-local/cuda-driver-dev-9-1-9.1.85-1.x86_64.rpm && \
@@ -70,7 +66,6 @@ RUN rpm --quiet -i cuda-repo-rhel6-9-1-local-9.1.85-1.x86_64.rpm && \
     rpm --quiet -i --nodeps --nomd5 /var/cuda-repo-9-1-local/cuda-nvrtc-dev-9-1-9.1.85-1.x86_64.rpm && \
     rpm --quiet -i --nodeps --nomd5 /var/cuda-repo-9-1-local/cuda-runtime-9-1-9.1.85-1.x86_64.rpm && \
     yum --nogpgcheck localinstall -y --quiet /var/cuda-repo-9-1-local/cuda-driver-dev-9-1-9.1.85-1.x86_64.rpm && \
-    rm -rf /cuda-repo-rhel6-9-1-local-9.1.85-1.x86_64.rpm /var/cuda-repo-9-1-local/*.rpm /var/cache/yum/cuda-9-1-local/
-
-RUN yum clean -y --quiet expire-cache && \
+    rm -rf /cuda-repo-rhel6-9-1-local-9.1.85-1.x86_64.rpm /var/cuda-repo-9-1-local/*.rpm /var/cache/yum/cuda-9-1-local/ && \
+    yum clean -y --quiet expire-cache && \
     yum clean -y --quiet all


### PR DESCRIPTION
This changes the main Dockerfile to no longer download files through Docker `ADD` directive and instead through `curl` on the same layer which removes it in the end. `ADD` creates layers that has to be downloaded even if the merged final image removes the files.

Several `ADD` and `RUN` lines were combined into other lines or removed to cut down on the total number of layers that have to be downloaded and extracted.

Some redundant `yum` lines were removed as well.

With this, the final uncompressed size of the image is ~1.9 GB, which is much better than the 10.3GB it was at the start of today and the 5.7GB it was after fixing the TeX install earlier.

Cleans up most of what #8 was going for. Could probably still be optimized with what of TeX and CUDA get installed, but this alone should be sufficient for a long while.