### PR TITLE
Create a base Conda-Forge Texlive derivative image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM condaforge/linux-anvil
 
-# Install TeXLive, AMD APP SDK 3.0, and NVIDIA CUDA 9.1 for building OpenMM and Omnia projects
+# Install TeXLive 2018 for Omnia Projects
 
 #
 # Install EPEL and extra packages
@@ -8,7 +8,7 @@ FROM condaforge/linux-anvil
 
 # CUDA requires dkms libvdpau
 # TeX installation requires wget and perl
-# The other TeX packages installed with `tlmgr install` are required for OpenMM's sphinx docs
+# The other TeX packages installed with `tlmgr install` are required for OpenMM's sphinx doc
 # libXext libSM libXrender are required for matplotlib to work
 
 # Download and install EPEL, install extra packages for TeX, AMD, and CUDA, cleanup yum
@@ -20,53 +20,32 @@ RUN curl -L http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8
     yum clean -y --quiet all
 
 #
-# Install TeXLive
+# Install GLIBC 2.14 for TeXLive 2018 which needs full C++11 to run
+
+RUN curl -L https://ftp.gnu.org/gnu/libc/glibc-2.14.tar.gz --output glibc-2.14.tar.gz && \
+    tar -zxf glibc-2.14.tar.gz && \
+    cd glibc-2.14 && \
+    mkdir build && \
+    cd build && \
+    CC=/opt/rh/devtoolset-2/root/usr/bin/gcc ../configure --prefix=/opt/glibc-2.14 && \
+    make -s && make -s install && \
+    cd / && rm -rf glibc*
+
+#
+# Install TeXLive 2018
 #
 
 # Add config file from repo
 ADD texlive.profile .
 # Download, untar, install, remove install files, install additional packages, make symlinks for all users
-RUN curl -L http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz --output install-tl-unx.tar.gz && \
+RUN export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/glibc-2.14/lib && \
+    curl -L http://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz --output install-tl-unx.tar.gz && \
     tar -xzf install-tl-unx.tar.gz && \
-    cd install-tl-* &&  ./install-tl -profile /texlive.profile && cd - && \
+    cd install-tl-* && ./install-tl -profile /texlive.profile && cd - && \
     rm -rf install-tl-unx.tar.gz install-tl-* texlive.profile && \
-    /usr/local/texlive/2017/bin/x86_64-linux/tlmgr install \
+    /usr/local/texlive/2018/bin/x86_64-linux/tlmgr install \
           cmap fancybox titlesec framed fancyvrb threeparttable \
           mdwtools wrapfig parskip upquote float multirow hyphenat caption \
           xstring fncychap tabulary capt-of eqparbox environ trimspaces && \
-    ln -s /usr/local/texlive/2017/bin/x86_64-linux/* /usr/local/sbin/
-ENV PATH=/usr/local/texlive/2017/bin/x86_64-linux:$PATH
-
-
-#
-# Install AMD APP SDK 3.0
-#
-
-
-# Download, untar, install AMD APP SDK, remove tarball, install script, and samples
-RUN curl -L http://s3.amazonaws.com/omnia-ci/AMD-APP-SDKInstaller-v3.0.130.135-GA-linux64.tar.bz2 > AMD-APP-SDKInstaller-v3.0.130.135-GA-linux64.tar.bz2 && \
-    tar xjf AMD-APP-SDKInstaller-v3.0.130.135-GA-linux64.tar.bz2 && \
-    ./AMD-APP-SDK-v3.0.130.135-GA-linux64.sh -- -s -a yes && \
-    rm -f AMD-APP-SDK-v3.0.130.135-GA-linux64.sh AMD-APP-SDKInstaller-v3.0.130.135-GA-linux64.tar.bz2 && \
-    rm -rf /opt/AMDAPPSDK-3.0/samples/
-ENV OPENCL_HOME=/opt/AMDAPPSDK-3.0 OPENCL_LIBPATH=/opt/AMDAPPSDK-3.0/lib/x86_64
-
-#
-# Install CUDA 9.0
-#
-
-# Install minimal CUDA components (this may be more than needed)
-RUN curl -L https://developer.nvidia.com/compute/cuda/9.1/Prod/local_installers/cuda-repo-rhel6-9-1-local-9.1.85-1.x86_64 > cuda-repo-rhel6-9-1-local-9.1.85-1.x86_64.rpm && \
-    rpm --quiet -i cuda-repo-rhel6-9-1-local-9.1.85-1.x86_64.rpm && \
-    yum --nogpgcheck localinstall -y --quiet /var/cuda-repo-9-1-local/cuda-minimal-build-9-1-9.1.85-1.x86_64.rpm && \
-    yum --nogpgcheck localinstall -y --quiet /var/cuda-repo-9-1-local/cuda-cufft-dev-9-1-9.1.85-1.x86_64.rpm && \
-    yum --nogpgcheck localinstall -y --quiet /var/cuda-repo-9-1-local/cuda-driver-dev-9-1-9.1.85-1.x86_64.rpm && \
-    rpm --quiet -i --nodeps --nomd5 /var/cuda-repo-9-1-local/xorg-x11-drv-nvidia-libs-387.26-1.el6.x86_64.rpm && \
-    rpm --quiet -i --nodeps --nomd5 /var/cuda-repo-9-1-local/xorg-x11-drv-nvidia-devel-387.26-1.el6.x86_64.rpm && \
-    rpm --quiet -i --nodeps --nomd5 /var/cuda-repo-9-1-local/cuda-nvrtc-9-1-9.1.85-1.x86_64.rpm && \
-    rpm --quiet -i --nodeps --nomd5 /var/cuda-repo-9-1-local/cuda-nvrtc-dev-9-1-9.1.85-1.x86_64.rpm && \
-    rpm --quiet -i --nodeps --nomd5 /var/cuda-repo-9-1-local/cuda-runtime-9-1-9.1.85-1.x86_64.rpm && \
-    yum --nogpgcheck localinstall -y --quiet /var/cuda-repo-9-1-local/cuda-driver-dev-9-1-9.1.85-1.x86_64.rpm && \
-    rm -rf /cuda-repo-rhel6-9-1-local-9.1.85-1.x86_64.rpm /var/cuda-repo-9-1-local/*.rpm /var/cache/yum/cuda-9-1-local/ && \
-    yum clean -y --quiet expire-cache && \
-    yum clean -y --quiet all
+    ln -s /usr/local/texlive/2018/bin/x86_64-linux/* /usr/local/sbin/
+ENV PATH=/usr/local/texlive/2018/bin/x86_64-linux:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,6 @@ RUN export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/glibc-2.14/lib && \
     /usr/local/texlive/2018/bin/x86_64-linux/tlmgr install \
           cmap fancybox titlesec framed fancyvrb threeparttable \
           mdwtools wrapfig parskip upquote float multirow hyphenat caption \
-          xstring fncychap tabulary capt-of eqparbox environ trimspaces && \
+          xstring fncychap tabulary capt-of eqparbox environ trimspaces varwidth latexmk && \
     ln -s /usr/local/texlive/2018/bin/x86_64-linux/* /usr/local/sbin/
 ENV PATH=/usr/local/texlive/2018/bin/x86_64-linux:$PATH

--- a/texlive.profile
+++ b/texlive.profile
@@ -2,13 +2,13 @@
 # It will NOT be updated and reflects only the
 # installation profile at installation time.
 selected_scheme scheme-full
-TEXDIR /usr/local/texlive/2017
-TEXMFCONFIG ~/.texlive2017/texmf-config
+TEXDIR /usr/local/texlive/2018
+TEXMFCONFIG ~/.texlive2018/texmf-config
 TEXMFHOME ~/texmf
 TEXMFLOCAL /usr/local/texlive/texmf-local
-TEXMFSYSCONFIG /usr/local/texlive/2017/texmf-config
-TEXMFSYSVAR /usr/local/texlive/2017/texmf-var
-TEXMFVAR ~/.texlive2017/texmf-var
+TEXMFSYSCONFIG /usr/local/texlive/2018/texmf-config
+TEXMFSYSVAR /usr/local/texlive/2018/texmf-var
+TEXMFVAR ~/.texlive2018/texmf-var
 binary_x86_64-linux 1
 collection-basic 1
 collection-bibtexextra 0


### PR DESCRIPTION
This is part of a multi-stage set of new docker images I am proposing, allowing us to switch back to a conda-forge base if we can get omnia-md/conda-dev-recipes#154 in. This is the base I propose. 

From here I will add a new image which pulls from this one but also adds all the minimal set of CUDA versions in parallel. From my local testing, the master CUDA image will be slightly *smaller* than the `omnia-linux-anvil:texlive18-cuda100` image. But we can discuss more in its own PR if this one gets merged in.

I have gone with the tag name "cf-...." to indicate its a conda-forge derivative rather than one built from scratch.