### PR TITLE
Add missing texlive packages for Sphinx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,7 +149,7 @@ RUN export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/glibc-2.14/lib && \
     /usr/local/texlive/2018/bin/x86_64-linux/tlmgr install \
           cmap fancybox titlesec framed fancyvrb threeparttable \
           mdwtools wrapfig parskip upquote float multirow hyphenat caption \
-          xstring fncychap tabulary capt-of eqparbox environ trimspaces && \
+          xstring fncychap tabulary capt-of eqparbox environ trimspaces varwidth latexmk && \
     ln -s /usr/local/texlive/2018/bin/x86_64-linux/* /usr/local/sbin/
 ENV PATH=/usr/local/texlive/2018/bin/x86_64-linux:$PATH
 


### PR DESCRIPTION
This should help advance omnia-md/conda-recipes#911 by pushing a change to the base docker image for the conda-build version workaround. 

Once this is merged in @jchodera , all you should have to do is have this build on your Docker account (automatic?), then re-trigger all the various `cuda` images.