### PR TITLE
Add in a driver file to get the base libcuda available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ FROM omniamd/omnia-linux-anvil:condaforge-texlive18
 #         A full install moves these but we don't need to, UNLESS we install the patch (e.g. the 3 patches for 9.1)
 
 # NOTE: NONE of these install the actual CUDA *DRIVER* as they would conflict with each other
-# We COULD install 1 driver at the end which is backwards compatible with the various CUDA versions, but this is still up for debate
+# We instead install 1 driver at the end which is backwards compatible with the various CUDA versions and adds a single
+# libcuda.so to /usr/lib64, which is needed by OpenMM to detect CUDA_CUDA_LIBRARY [sic] and different from /usr/local
+# installs of the cuda veersions below
 
 # CUDA 7.5
 RUN curl -L http://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers/cuda-repo-rhel6-7-5-local-7.5-18.x86_64.rpm > cuda-repo-rhel6-7-5-local-7.5-18.x86_64.rpm && \
@@ -114,3 +116,10 @@ RUN curl -L https://developer.nvidia.com/compute/cuda/10.0/Prod/local_installers
     rm -rf /cuda-repo-rhel6-10-0-local-10.0.130-410.48-1.0-1.x86_64.rpm /var/cuda-repo-10-0-local-10.0.130-410.48/*.rpm /var/cache/yum/cuda-repo-10-0-local-10.0.130-410.48/ && \
     yum clean -y --quiet expire-cache && \
     yum clean -y --quiet all
+
+# Finally, install *a* NVIDIA driver, use the "long lived branch"  one
+# https://www.nvidia.com/object/unix.html
+RUN wget -q http://us.download.nvidia.com/XFree86/Linux-x86_64/410.93/NVIDIA-Linux-x86_64-410.93.run && \
+    chmod +x NVIDIA-Linux-x86_64-410.93.run && \
+    ./NVIDIA-Linux-x86_64-410.93.run --silent --accept-license --no-kernel-module --no-kernel-module-source --no-nvidia-modprobe --no-rpms --no-drm --no-libglx-indirect --no-distro-scripts && \
+    rm -f NVIDIA-Linux-x86_64-410.93.run

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ FROM omniamd/omnia-linux-anvil:condaforge-texlive18
 # NOTE: NONE of these install the actual CUDA *DRIVER* as they would conflict with each other
 # We instead install 1 driver at the end which is backwards compatible with the various CUDA versions and adds a single
 # libcuda.so to /usr/lib64, which is needed by OpenMM to detect CUDA_CUDA_LIBRARY [sic] and different from /usr/local
-# installs of the cuda veersions below
+# installs of the cuda veersions below.
+# Unsure if we need the driver or the files in the `cuda-XX.Y/lib64/stubs` folder for each CUDA version
 
 # CUDA 7.5
 RUN curl -L http://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers/cuda-repo-rhel6-7-5-local-7.5-18.x86_64.rpm > cuda-repo-rhel6-7-5-local-7.5-18.x86_64.rpm && \


### PR DESCRIPTION
This adds a driver at the very end of the install to ensure a `libcuda.so` exists in `/usr/lib64/` which is needed by OpenMM to detect `CUDA_CUDA_LIBRARY` [sic], but still not clash with  the specific cuda versions. 